### PR TITLE
fix: support for older ECMAScript versions

### DIFF
--- a/src/hooks/useDurationInput.ts
+++ b/src/hooks/useDurationInput.ts
@@ -182,7 +182,7 @@ export function useDurationInput({
 }
 
 function useDurationModifiers(modifiers: DurationModifier[]) {
-  const sortedModifiers = modifiers.toSorted(
+  const sortedModifiers = [...modifiers].sort(
     (a, b) => b.multiplier - a.multiplier,
   );
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "target": "es2023",
+    "target": "es2022",
     "module": "es2022",
     "moduleResolution": "node",
     "esModuleInterop": true,


### PR DESCRIPTION
Browsers running on Windows 8 or earlier don't support new ECMAScript versions, and the latest experienced and noticed is ES2022. Downgraded the ECMAScript accordingly.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Updated internal sorting approach for duration modifiers to improve compatibility.
	- Adjusted TypeScript configuration to target an earlier ECMAScript version for broader support.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->