### PR TITLE
fix(uinjector): react integration

### DIFF
--- a/src/components/UInjector.tsx
+++ b/src/components/UInjector.tsx
@@ -158,10 +158,10 @@ export function UInjector(props: UInjectorProps) {
       }
 
       return () => {
+        observer.disconnect();
         for (const { node, target } of movedNodes) {
           target.append(node);
         }
-        observer.disconnect();
       };
     } else {
       for (const [trackableTarget, wrappingContainer] of wrappingContainers) {

--- a/src/components/UInjector.tsx
+++ b/src/components/UInjector.tsx
@@ -153,7 +153,7 @@ export function UInjector(props: UInjectorProps) {
         moveNodesToTarget(nodes, trackableTarget.element);
         observer.observe(wrappingContainer, { childList: true });
         nodes.forEach((node) =>
-          movedNodes.push({ node, target: trackableTarget.element }),
+          movedNodes.push({ node, target: wrappingContainer }),
         );
       }
 

--- a/src/components/UInjector.tsx
+++ b/src/components/UInjector.tsx
@@ -261,7 +261,7 @@ function useWrappingContainers<E extends Element = Element>(
         transformedContainersMap.current.get(container);
       if (appliedTransformer) {
         if (appliedTransformer.transformer === containerTransformer) continue;
-        appliedTransformer?.destructor();
+        appliedTransformer?.destructor?.();
       }
 
       const destructor = containerTransformer?.(container);

--- a/src/components/UInjector.tsx
+++ b/src/components/UInjector.tsx
@@ -17,12 +17,12 @@ import { createPortal } from 'react-dom';
 import { arrayExclusion } from 'utils/array';
 import { isElementNode } from 'utils/node-utils';
 
-export interface UInjectorRenderUIOptions {
+export interface UInjectorRenderUIOptions<E extends Element = Element> {
   /** The target DOM element for which the UI will be injected */
-  target: Element;
+  target: E;
 }
 
-export interface UInjectorProps {
+export interface UInjectorProps<E extends Element = Element> {
   /**
    * Specifies the container to observe for mutations. Either a direct {@link Element} node,
    * or a {@link String string} representing the query selector for the container.
@@ -65,7 +65,7 @@ export interface UInjectorProps {
    * @param options The options object containing the target element.
    * @returns The React node to render.
    */
-  renderUI(options: UInjectorRenderUIOptions): ReactNode;
+  renderUI(options: UInjectorRenderUIOptions<E>): ReactNode;
 
   /**
    * Should the injector wrap your target UI within its own container.
@@ -86,7 +86,9 @@ export interface UInjectorProps {
    */
   containerTransformer?: (container: HTMLDivElement) => void | (() => void);
 }
-export function UInjector(props: UInjectorProps) {
+export function UInjector<E extends Element = Element>(
+  props: UInjectorProps<E>,
+) {
   const containerToObserve: Element = useMemo(() => {
     if (!props.observedContainer) return document.body;
 
@@ -96,12 +98,12 @@ export function UInjector(props: UInjectorProps) {
     return document.querySelector(props.observedContainer);
   }, [props.observedContainer]);
 
-  const matchingTargets = useQuerySelectorAll(
+  const matchingTargets = useQuerySelectorAll<E>(
     containerToObserve,
     props.targetSelector,
-    props.targetFilter as (element: Element) => element is Element,
+    props.targetFilter as (element: Element) => element is E,
   );
-  const wrappingContainers = useWrappingContainers(
+  const wrappingContainers = useWrappingContainers<E>(
     matchingTargets,
     props.containerTransformer,
   );

--- a/src/components/UInjector.tsx
+++ b/src/components/UInjector.tsx
@@ -8,6 +8,7 @@ import {
   ReactNode,
   useCallback,
   useEffect,
+  useLayoutEffect,
   useMemo,
   useRef,
   useState,
@@ -131,7 +132,7 @@ export function UInjector(props: UInjectorProps) {
     [props.position],
   );
 
-  useEffect(() => {
+  useLayoutEffect(() => {
     if (!(props.wrapInContainer ?? true)) {
       const movedNodes: Array<{ node: Node; target: Element }> = [];
 


### PR DESCRIPTION
### Background

React manages the DOM state and provides several hooks to run effects at different phases of the render. Our `UInjector` allows to define different insertion points for elements using a virtual `DIV` container served as the host, and we were tracking and observing this `DIV` and moving the nodes to their position accordingly to the rules of `UInjector` in an effect hook, and the cleanup function was intended to move the nodes back to the virtual `DIV` when unmounting.

### The Issue

React calls the cleanup function only when unmounting the most immediate root, which is our virtual `DIV`. This caused React to try to remove the elements we were rendering from the virtual `DIV` before the cleanup function had run, and therefore before moving the nodes back to the virtual `DIV`.

### The Solution

Intercept the `removeChild` method of the virtual `DIV` – this is the method React calls to remove (and the only one available in the DOM) child nodes from it. Test if the node in question for removal is a node we've manipulated and moved, and if so, redirect the call to the "current" host of the children, and remove its reference from our list to remove back to the virtual `DIV`.