### PR TITLE
refactor: update symbol declarations to use unique symbol type

### DIFF
--- a/src/method-interceptor/lib/utils/intercept-after-invocation.ts
+++ b/src/method-interceptor/lib/utils/intercept-after-invocation.ts
@@ -1,9 +1,9 @@
 import { KeysOfFunctions } from '../keys-of-type.js';
 import { InterceptionFunction } from '../method-interceptor.js';
 
-export const RETURN_ORIGINAL_VALUE = Symbol(
+export const RETURN_ORIGINAL_VALUE: unique symbol = Symbol(
   'RETURN ORIGINAL INVOCATION VALUE',
-) as unknown as symbol & { __lock: 'RET_ORIG_INVOKE_VAL' };
+);
 
 export function interceptAfterInvocation<
   // eslint-disable-next-line @typescript-eslint/no-explicit-any

--- a/src/method-interceptor/lib/utils/intercept-before-invocation.ts
+++ b/src/method-interceptor/lib/utils/intercept-before-invocation.ts
@@ -1,7 +1,7 @@
 import { KeysOfFunctions } from '../keys-of-type.js';
 import { InterceptionFunction } from '../method-interceptor.js';
 
-export const CONTINUE_INVOCATION = Symbol('CONTINUE INVOCATION') as unknown as symbol & { __lock: 'CONTINUE_INVOCATION_SYMBOL' };
+export const CONTINUE_INVOCATION: unique symbol = Symbol('CONTINUE INVOCATION');
 
 export function interceptBeforeInvocation<
   // eslint-disable-next-line @typescript-eslint/no-explicit-any


### PR DESCRIPTION
This removes the workaround with a custom object with a custom unique property to each Symbol and utilizes TypeScript's official feature instead