### PR TITLE
feat: add disclaimer for single occurrence closures presets

### DIFF
--- a/src/components/closure-presets/preset-edit-dialog/steps/ClosureDetailsStep.tsx
+++ b/src/components/closure-presets/preset-edit-dialog/steps/ClosureDetailsStep.tsx
@@ -97,14 +97,22 @@ export function ClosureDetailsStep() {
           />
         </ToggleGroup>
         {startDate?.type === 'DAY_OF_WEEK' && (
-          <WeekdayPicker
-            fullWidth
-            value={startDate.value}
-            allowMultiple
-            onChange={(day) =>
-              setStartDate({ type: 'DAY_OF_WEEK', value: day })
-            }
-          />
+          <>
+            <WeekdayPicker
+              fullWidth
+              value={startDate.value}
+              allowMultiple
+              onChange={(day) =>
+                setStartDate({ type: 'DAY_OF_WEEK', value: day })
+              }
+            />
+
+            <wz-caption>
+              {t(
+                'edit.closure_preset.edit_dialog.steps.CLOSURE_DETAILS.closure_start_date.day_of_week_disclaimer',
+              )}
+            </wz-caption>
+          </>
         )}
       </div>
 

--- a/src/localization/static/userscript.json
+++ b/src/localization/static/userscript.json
@@ -81,7 +81,8 @@
                 "UNKNOWN": "Not set",
                 "CURRENT_DATE": "Activation Date",
                 "DAY_OF_WEEK": "Specific Day"
-              }
+              },
+              "day_of_week_disclaimer": "This preset creates a single closure. If multiple weekdays are selected, it will use the soonest upcoming day. This preset is not for recurring closures."
             },
             "closure_start_time": {
               "label": "Closure's start time",


### PR DESCRIPTION
This pull request adds a disclaimer explicitly mentioning that presets activated on a specific day are created for single occurrence and do not support recurrence rules. It'll be only shown if the preset start's day mode is set to a specific day and will be shown below the day picker.

This minor change is essential because some users have mistakenly thinking that setting there multiple days will create a recurring closure, rather than creating a single occurrence closure on the soonest match.