### PR TITLE
feat: add commit hash to logs and debug menu

### DIFF
--- a/rollup.config.ts
+++ b/rollup.config.ts
@@ -7,6 +7,7 @@ import terser from '@rollup/plugin-terser';
 import replace from '@rollup/plugin-replace';
 import addBanner from './rollup-plugin-add-banner';
 import svgr from '@svgr/rollup';
+import { execSync } from 'child_process';
 
 import packageMetadata from './package.json';
 
@@ -25,6 +26,17 @@ const packageAuthor =
     packageMetadata.author) ||
   packageNamespace?.substring(1) ||
   'Unknown';
+
+// Get the current Git commit hash
+const getCommitHash = () => {
+  try {
+    // Get the short version of the commit hash (7 characters)
+    return execSync('git rev-parse --short HEAD').toString().trim();
+  } catch (error) {
+    console.error('Failed to get Git commit hash:', error);
+    return 'unknown';
+  }
+};
 
 const scriptName =
   ('displayName' in packageMetadata &&
@@ -81,6 +93,7 @@ export default {
         convertStringConvention(packagePureName, 'PascalCase'),
       ),
       __SCRIPT_VERSION__: JSON.stringify(packageMetadata.version),
+      __COMMIT_HASH__: JSON.stringify(getCommitHash()),
       __BUILD_TIME__: JSON.stringify(new Date()),
       'process.env.CROWDIN_DISTRIBUTION_HASH': JSON.stringify(
         process.env.CROWDIN_DISTRIBUTION_HASH || '15dd9243e7c0c5a4cad8d58031c',

--- a/src/build-time-variables.d.ts
+++ b/src/build-time-variables.d.ts
@@ -5,3 +5,4 @@ declare const __SCRIPT_SHORT_NAME__: string;
 declare const __SCRIPT_CAMEL_CASE_NAME__: string;
 declare const __SCRIPT_VERSION__: string;
 declare const __BUILD_TIME__: string;
+declare const __COMMIT_HASH__: string;

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -50,6 +50,7 @@ Logger.debug('Logger initialized.');
 Logger.debug('Starting session', {
   sessionId: SessionId,
   version: __SCRIPT_VERSION__,
+  commitHash: __COMMIT_HASH__,
   buildTime: __BUILD_TIME__,
   browserInfo: {
     userAgent: navigator.userAgent,
@@ -208,7 +209,7 @@ root.render(
             debugInfoItem.innerHTML = `
               <wz-overline>${__SCRIPT_SHORT_NAME__} Debug Menu</wz-overline>
               <div style="display: flex; flex-direction: column">
-                <wz-caption>Version: ${__SCRIPT_VERSION__}</wz-caption>
+                <wz-caption>Version: ${__SCRIPT_VERSION__}-${__COMMIT_HASH__}</wz-caption>
                 <wz-caption>Build time: ${__BUILD_TIME__}</wz-caption>
               </div>
             `;


### PR DESCRIPTION
> [!IMPORTANT]
> Junie wrote the code.

This pull request adds the commit hash to the logs and to the debug menu.
It executes git as a child process to get the commit, and replaces it during compilation using Rollup's replace plugin. 

Closes #82 