### PR TITLE
feat(CP): add "round up to" option for durational end times in presets

### DIFF
--- a/src/components/closure-presets/preset-edit-dialog/PresetEditDialog.tsx
+++ b/src/components/closure-presets/preset-edit-dialog/PresetEditDialog.tsx
@@ -94,6 +94,7 @@ export function PresetEditingDialog(props: PresetEditingDialogProps) {
                 hours: Math.floor(durationInMinutes / 60),
                 minutes: durationInMinutes % 60,
               },
+              roundUpTo: closureDetailsData.endTime!.roundUpTo,
             };
             break;
           }
@@ -180,6 +181,7 @@ export function PresetEditingDialog(props: PresetEditingDialogProps) {
                 duration:
                   props.preset.closureDetails.end.duration.hours * 60 +
                   props.preset.closureDetails.end.duration.minutes,
+                roundUpTo: props.preset.closureDetails.end.roundUpTo,
               }
             : null,
         },

--- a/src/components/closure-presets/preset-edit-dialog/interfaces/preset-edit-dialog-data.ts
+++ b/src/components/closure-presets/preset-edit-dialog/interfaces/preset-edit-dialog-data.ts
@@ -29,6 +29,7 @@ export type PresetEditDialogData = {
       | {
           type: 'DURATIONAL';
           duration: number;
+          roundUpTo?: number;
         };
   };
 } & {

--- a/src/db/db.ts
+++ b/src/db/db.ts
@@ -19,4 +19,19 @@ db.version(2)
       });
   });
 
+db.version(3)
+  .stores({
+    closurePresets: '++id, name, createdAt, updatedAt',
+  })
+  .upgrade((transaction) => {
+    return transaction
+      .table('closurePresets')
+      .toCollection()
+      .modify((closurePreset: ClosurePreset) => {
+        if (closurePreset.closureDetails.end.type !== 'DURATIONAL') return;
+        // Initialize roundUpTo as undefined for existing durational presets
+        closurePreset.closureDetails.end.roundUpTo = undefined;
+      });
+  });
+
 export { db };

--- a/src/interfaces/closure-preset.ts
+++ b/src/interfaces/closure-preset.ts
@@ -14,6 +14,7 @@ interface ClosureDurationalEnd {
     hours: number;
     minutes: number;
   };
+  roundUpTo?: number; // in minutes: 10, 15, 30, 60
 }
 
 export interface ClosurePresetMetadata {

--- a/src/localization/static/userscript.json
+++ b/src/localization/static/userscript.json
@@ -97,7 +97,14 @@
                 "FIXED": "Specific time",
                 "DURATIONAL": "Durational"
               },
-              "postpone_by": "Postpone by"
+              "postpone_by": "Postpone by",
+              "round_up_to": "Round up to",
+              "round_up_options": {
+                "10_minutes": "10 minutes",
+                "15_minutes": "15 minutes",
+                "30_minutes": "30 minutes",
+                "hour": "Hour"
+              }
             }
           },
           "SUMMARY": {

--- a/src/utils/apply-closure-preset.ts
+++ b/src/utils/apply-closure-preset.ts
@@ -69,13 +69,33 @@ function getEndDateForPreset(
   });
 
   switch (endDetails.type) {
-    case 'DURATIONAL':
-      return new Date(
+    case 'DURATIONAL': {
+      const endDate = new Date(
         startDate.getTime() +
           (endDetails.duration.hours * 3600 +
             endDetails.duration.minutes * 60) *
             1000,
       );
+
+      if (endDetails.roundUpTo) {
+        logger.debug(
+          `Rounding up the end time to the nearest ${endDetails.roundUpTo} minutes`,
+        );
+        const minutes = endDate.getMinutes();
+        const roundUpToMinutes = endDetails.roundUpTo;
+        const remainder = minutes % roundUpToMinutes;
+
+        if (remainder > 0) {
+          // Round up to the next interval
+          const minutesToAdd = roundUpToMinutes - remainder;
+          endDate.setMinutes(minutes + minutesToAdd);
+          // Reset seconds and milliseconds
+          endDate.setSeconds(0, 0);
+        }
+      }
+
+      return endDate;
+    }
     case 'FIXED': {
       const startTime = new TimeOnly(startDate);
       const endTime = new TimeOnly(


### PR DESCRIPTION
This pull request introduces a new feature to support "rounding up" closure end times to predefined intervals (e.g., 10, 15, 30, or 60 minutes). The changes span multiple files and involve both UI enhancements and backend adjustments to ensure the feature is fully integrated.

### Backend Changes:
* **Database Schema Update**: Added a new `roundUpTo` field to the `closurePresets` table, with an upgrade script to initialize the field as `undefined` for existing durational presets. (`src/db/db.ts`)
* **Interface Update**: Extended the `ClosureDurationalEnd` interface to include an optional `roundUpTo` property. (`src/interfaces/closure-preset.ts`)
* **Logic Enhancement**: Modified `getEndDateForPreset` to round up the end time to the nearest interval if `roundUpTo` is specified. (`src/utils/apply-closure-preset.ts`)

### Frontend Changes:
* **Preset Editing Dialog**: Updated `PresetEditingDialog` to support the `roundUpTo` property when handling closure details. (`src/components/closure-presets/preset-edit-dialog/PresetEditDialog.tsx`) [[1]](diffhunk://#diff-d9df384897f58e9dedc83f85b1d3b9d3a6c7c04677faa77b277eeb80bcd098adR97) [[2]](diffhunk://#diff-d9df384897f58e9dedc83f85b1d3b9d3a6c7c04677faa77b277eeb80bcd098adR184)
* **Closure Details Step**: Added UI elements for enabling/disabling rounding and selecting the interval, including logic to persist and restore the `roundUpTo` value. (`src/components/closure-presets/preset-edit-dialog/steps/ClosureDetailsStep.tsx`) [[1]](diffhunk://#diff-0aa45ef9b28b200d6cc44d48763b57d2e0351a1032a3a36c1300fff3d1581d51R41-R46) [[2]](diffhunk://#diff-0aa45ef9b28b200d6cc44d48763b57d2e0351a1032a3a36c1300fff3d1581d51R362-R470)

### Localization:
* **Translation Updates**: Added new localization keys for "round up to" and its options (10 minutes, 15 minutes, etc.). (`src/localization/static/userscript.json`)

### Linked Issues

Closes: #73.