### PR TITLE
fix(ClosureEditorPanel): update target selector for UInjectorComponent

### DIFF
--- a/src/components/portals/closure-editor-panel/ClosureEditorPanel.tsx
+++ b/src/components/portals/closure-editor-panel/ClosureEditorPanel.tsx
@@ -66,7 +66,7 @@ function ClosureEditorPanel(props: ClosureEditorPanelProps) {
 }
 
 const UInjectorComponent = asUInjectorComponent(ClosureEditorPanel, {
-  targetSelector: '.edit-closure',
+  targetSelector: '.closure form',
   position: 'BEFORE',
   wrapInContainer: false,
 });


### PR DESCRIPTION
This is due to class name changes. Updated with a more precise selector, targeting firstly the closure card (by class) and then the form