### PR TITLE
feat(logger): replace js-logger with @editor-x/wme-logstream

### DIFF
--- a/__mocks__/@editor-x/wme-logstream.ts
+++ b/__mocks__/@editor-x/wme-logstream.ts
@@ -1,0 +1,30 @@
+export class LogStream {
+  static create() {
+    return new LogStream();
+  }
+  scope() {
+    return this;
+  }
+  trace() {}
+  debug() {}
+  info() {}
+  warn() {}
+  error() {}
+  fatal() {}
+  stateDelta() {}
+  createStateTracker() {
+    return () => {};
+  }
+  exportLogs() {
+    return Promise.resolve(new Blob());
+  }
+  downloadLogs() {
+    return Promise.resolve();
+  }
+  flush() {
+    return Promise.resolve();
+  }
+  close() {
+    return Promise.resolve();
+  }
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "1.0.2",
       "dependencies": {
         "@base-ui-components/react": "^1.0.0-alpha.8",
+        "@editor-x/wme-logstream": "^0.1.0-alpha.1",
         "@emotion/css": "^11.13.5",
         "@emotion/react": "^11.14.0",
         "@emotion/styled": "^11.14.0",
@@ -17,7 +18,6 @@
         "concurrently": "^9.1.2",
         "dexie": "^4.0.11",
         "dexie-react-hooks": "^1.1.7",
-        "js-logger": "^1.6.1",
         "react": "^19.0.0",
         "react-dom": "^19.0.0",
         "usehooks-ts": "^3.1.1"
@@ -2022,6 +2022,12 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@dmsnell/diff-match-patch": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@dmsnell/diff-match-patch/-/diff-match-patch-1.1.0.tgz",
+      "integrity": "sha512-yejLPmM5pjsGvxS9gXablUSbInW7H976c/FJ4iQxWIm7/38xBySRemTPDe34lhg1gVLbJntX0+sH0jYfU+PN9A==",
+      "license": "Apache-2.0"
+    },
     "node_modules/@editor-x/rollup-plugin-userscript": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/@editor-x/rollup-plugin-userscript/-/rollup-plugin-userscript-1.0.0.tgz",
@@ -2031,6 +2037,16 @@
       "dependencies": {
         "acorn": "^8.15.0",
         "acorn-walk": "^8.3.4"
+      }
+    },
+    "node_modules/@editor-x/wme-logstream": {
+      "version": "0.1.0-alpha.1",
+      "resolved": "https://registry.npmjs.org/@editor-x/wme-logstream/-/wme-logstream-0.1.0-alpha.1.tgz",
+      "integrity": "sha512-1lpAtdotx+LySvuOgTx45tUxj0QaK7YEU0/6i7aGHKyMzKRQfWOJ8askXYj6fajXS7FjDA2//XUxM0UhuYvkrw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "fflate": "^0.8.3",
+        "jsondiffpatch": "^0.7.6"
       }
     },
     "node_modules/@emotion/babel-plugin": {
@@ -6851,6 +6867,12 @@
         }
       }
     },
+    "node_modules/fflate": {
+      "version": "0.8.3",
+      "resolved": "https://registry.npmjs.org/fflate/-/fflate-0.8.3.tgz",
+      "integrity": "sha512-tbZNuJrLwGUp3zshBtdy4W+ORxZuIh8a5ilyIEQDC5rY1f3U20JMry0Ll3WBzU58EZKsEuJFXhb5gwv8CsPvgA==",
+      "license": "MIT"
+    },
     "node_modules/file-entry-cache": {
       "version": "8.0.0",
       "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-8.0.0.tgz",
@@ -9052,12 +9074,6 @@
         "url": "https://github.com/chalk/supports-color?sponsor=1"
       }
     },
-    "node_modules/js-logger": {
-      "version": "1.6.1",
-      "resolved": "https://registry.npmjs.org/js-logger/-/js-logger-1.6.1.tgz",
-      "integrity": "sha512-yTgMCPXVjhmg28CuUH8CKjU+cIKL/G+zTu4Fn4lQxs8mRFH/03QTNvEFngcxfg/gRDiQAOoyCKmMTOm9ayOzXA==",
-      "license": "MIT"
-    },
     "node_modules/js-tokens": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
@@ -9173,6 +9189,21 @@
       },
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/jsondiffpatch": {
+      "version": "0.7.6",
+      "resolved": "https://registry.npmjs.org/jsondiffpatch/-/jsondiffpatch-0.7.6.tgz",
+      "integrity": "sha512-zE9+AXFq+MkTolDor2Cw1nJzLC0aleqPkYf52Kb4Kn4mJcka/gFHpGI2JBVEJCfWOvBl0OoxZS+wuLdislQcqg==",
+      "license": "MIT",
+      "dependencies": {
+        "@dmsnell/diff-match-patch": "^1.1.0"
+      },
+      "bin": {
+        "jsondiffpatch": "bin/jsondiffpatch.js"
+      },
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
       }
     },
     "node_modules/jsx-ast-utils": {

--- a/package.json
+++ b/package.json
@@ -55,6 +55,7 @@
   "private": true,
   "dependencies": {
     "@base-ui-components/react": "^1.0.0-alpha.8",
+    "@editor-x/wme-logstream": "^0.1.0-alpha.1",
     "@emotion/css": "^11.13.5",
     "@emotion/react": "^11.14.0",
     "@emotion/styled": "^11.14.0",
@@ -63,7 +64,6 @@
     "concurrently": "^9.1.2",
     "dexie": "^4.0.11",
     "dexie-react-hooks": "^1.1.7",
-    "js-logger": "^1.6.1",
     "react": "^19.0.0",
     "react-dom": "^19.0.0",
     "usehooks-ts": "^3.1.1"

--- a/src/components/closure-presets/ClosurePresetEditorManager.tsx
+++ b/src/components/closure-presets/ClosurePresetEditorManager.tsx
@@ -1,10 +1,10 @@
-import Logger from 'js-logger';
 import { createContext, ReactNode, useContext, useMemo, useState } from 'react';
 import { useClosurePresetsListContext } from '../../contexts';
 import { ClosurePreset, ClosurePresetMetadata } from '../../interfaces';
 import { PresetEditingDialog } from './preset-edit-dialog';
+import { logger as baseLogger } from '../../utils/logger';
 
-const logger = Logger.get('preset-editor-manager');
+const logger = baseLogger.scope('preset-editor-manager');
 
 interface ClosurePresetEditorManager {
   openEditor(presetId?: ClosurePresetMetadata['id']): void;

--- a/src/components/dialogs/reccuring-closure-config-dialog/recurring-modes/daily-recurring-mode/daily-recurring-mode.ts
+++ b/src/components/dialogs/reccuring-closure-config-dialog/recurring-modes/daily-recurring-mode/daily-recurring-mode.ts
@@ -1,9 +1,9 @@
 import { Timeframe } from 'interfaces';
-import Logger from 'js-logger';
 import { RecurringMode } from '../recurring-mode';
 import { DailyConfigForm, DailyConfigFormFields } from './DailyConfigForm';
+import { logger as baseLogger } from '../../../../../utils/logger';
 
-const logger = Logger.get('DAILY_RECURRING_MODE');
+const logger = baseLogger.scope('DAILY_RECURRING_MODE');
 
 export const DailyRecurringMode: RecurringMode<DailyConfigFormFields> = {
   id: 'DAILY',

--- a/src/components/dialogs/reccuring-closure-config-dialog/recurring-modes/interval-recurring-mode/interval-recurring-mode.ts
+++ b/src/components/dialogs/reccuring-closure-config-dialog/recurring-modes/interval-recurring-mode/interval-recurring-mode.ts
@@ -1,11 +1,11 @@
 import { Timeframe } from 'interfaces';
-import Logger from 'js-logger';
 import { RecurringMode } from '../recurring-mode';
 import { IntervalAnchorPoint } from './enums';
 import { IntervalConfigForm } from './IntervalConfigForm';
 import { getDefaultAnchorPoint } from './utils';
+import { logger as baseLogger } from '../../../../../utils/logger';
 
-const logger = Logger.get('INTERVAL_RECURRING_MODE');
+const logger = baseLogger.scope('INTERVAL_RECURRING_MODE');
 
 export interface IntervalModeFields {
   /** The length of each closure in minutes */

--- a/src/consts/date-resolvers/day-of-week-resolver.ts
+++ b/src/consts/date-resolvers/day-of-week-resolver.ts
@@ -1,9 +1,9 @@
 import { WeekdayFlags } from 'enums';
-import Logger from 'js-logger';
 import { createDateResolver } from './date-resolver';
 import { DateOnly } from 'classes';
+import { logger as baseLogger } from '../../utils/logger';
 
-const logger = Logger.get('DAY_OF_WEEK_RESOLVER');
+const logger = baseLogger.scope('DAY_OF_WEEK_RESOLVER');
 
 interface DayOfWeekResolverArgs {
   /** The numeric representation of the day(s) of the week, to be used with the {@link WeekdayFlags} bitwise enum. */

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -1,5 +1,4 @@
 import axios from 'axios';
-import Logger from 'js-logger';
 import { createRoot } from 'react-dom/client';
 import { SessionId } from './consts/session-id';
 import { getCurrentLocale, loadCrowdinStrings } from './localization';
@@ -10,44 +9,12 @@ import { App } from './App';
 import { asScriptTab } from 'utils/as-script-tab';
 import PlusBranded from './assets/plus-branded.svg';
 import { WzMenuElement } from 'types/waze/elements';
+import { logger } from './utils/logger';
 
 import './utils/wme-date-format';
 
-const sessionLogs = [];
-const consoleLogger = (() => {
-  let lastConsoleOutput = NaN;
-
-  return Logger.createDefaultHandler({
-    formatter: (messages, context) => {
-      const currentTime = new Date();
-      const timeSinceLastMessage = currentTime.getTime() - lastConsoleOutput;
-      messages.unshift(
-        [
-          '[editorx.dev/closures-plus]',
-          currentTime.toISOString(),
-          !isNaN(timeSinceLastMessage) &&
-            `\x1B[32m+${timeSinceLastMessage}ms\x1B[m`,
-          context.name && `[\x1B[105;1m${context.name}\x1B[m]`,
-        ]
-          .filter(Boolean)
-          .join('\t'),
-      );
-      lastConsoleOutput = currentTime.getTime();
-    },
-  });
-})();
-Logger.setHandler((messages, context) => {
-  consoleLogger(messages, context);
-  sessionLogs.push({
-    time: new Date().toISOString(),
-    context,
-    messages,
-  });
-});
-
-Logger.setLevel(Logger.DEBUG);
-Logger.debug('Logger initialized.');
-Logger.debug('Starting session', {
+logger.debug('Logger initialized.');
+logger.debug('Starting session', {
   sessionId: SessionId,
   version: __SCRIPT_VERSION__,
   commitHash: __COMMIT_HASH__,
@@ -68,7 +35,7 @@ axios.defaults.adapter = axiosGmXhrAdapter;
 
 const [wmeSdk] = await Promise.all([
   await (async () => {
-    Logger.debug('Waiting for SDK to initialize...');
+    logger.debug('Waiting for SDK to initialize...');
     await SDK_INITIALIZED;
     const wmeSdk = await initWmeSdkPlus(
       getWmeSdk({
@@ -76,7 +43,7 @@ const [wmeSdk] = await Promise.all([
         scriptName: __SCRIPT_NAME__,
       }),
     );
-    Logger.debug('SDK initialized.', {
+    logger.debug('SDK initialized.', {
       username: wmeSdk.State.getUserInfo()?.userName,
       userRank: wmeSdk.State.getUserInfo()?.rank,
       wazeMapEditorInfo: {
@@ -95,7 +62,7 @@ const [wmeSdk] = await Promise.all([
   ),
 ]);
 
-Logger.debug('Starting app...');
+logger.debug('Starting app...');
 const root = createRoot(document.createDocumentFragment());
 const AppWrapper = asScriptTab(
   App,
@@ -119,47 +86,14 @@ root.render(
       const CLICK_TIMEOUT = 3000;
 
       const sendLogs = () => {
-        Logger.debug('Sending logs...');
-
-        // Collect browser and environment information
-        const browserInfo = {
-          userAgent: navigator.userAgent,
-          language: navigator.language,
-          platform: navigator.platform,
-          screenWidth: window.screen.width,
-          screenHeight: window.screen.height,
-          windowWidth: window.innerWidth,
-          windowHeight: window.innerHeight,
-        };
-
-        // Create a text blob with logs
-        const logData = {
-          sessionId: SessionId,
-          timestamp: new Date().toISOString(),
-          userInfo: wmeSdk.State.getUserInfo(),
-          browserInfo,
-          content: sessionLogs,
-        };
-
-        const logBlob = new Blob([JSON.stringify(logData, null, 2)], {
-          type: 'application/json',
-        });
-        const url = URL.createObjectURL(logBlob);
-
-        // Create a download link
-        const a = document.createElement('a');
-        a.href = url;
-        a.download = `wme-closures-plus-logs-${new Date().toISOString()}.json`;
-        document.body.appendChild(a);
-        a.click();
-
-        // Clean up
-        setTimeout(() => {
-          document.body.removeChild(a);
-          URL.revokeObjectURL(url);
-        }, 100);
-
-        Logger.debug('Logs sent');
+        logger.debug('Downloading logs...');
+        logger
+          .downloadLogs(
+            `wme-closures-plus-logs-${new Date().toISOString()}.xlog`,
+          )
+          .catch((err) => {
+            logger.error('Failed to download logs', err);
+          });
       };
 
       const handleContextMenu = (event: MouseEvent) => {
@@ -175,7 +109,7 @@ root.render(
         lastClickTime = currentTime;
 
         if (clickCount === 5) {
-          Logger.debug('Context menu triggered', { event });
+          logger.debug('Context menu triggered', { event });
           // Prevent default context menu on third click
           event.preventDefault();
 
@@ -244,4 +178,4 @@ root.render(
   />,
 );
 
-Logger.debug('Rendered. Idle');
+logger.debug('Rendered. Idle');

--- a/src/localization/utils/load-crowdin-strings.ts
+++ b/src/localization/utils/load-crowdin-strings.ts
@@ -1,8 +1,8 @@
-import Logger from 'js-logger';
 import { fetchRemoteStrings } from './fetch-remote-strings';
 import { loadStrings } from './load-strings';
+import { logger as baseLogger } from '../../utils/logger';
 
-const logger = Logger.get('i18n');
+const logger = baseLogger.scope('i18n');
 
 export async function loadCrowdinStrings(
   locale: string,

--- a/src/utils/apply-closure-preset.ts
+++ b/src/utils/apply-closure-preset.ts
@@ -2,9 +2,9 @@ import { ClosureEditorForm, DateOnly } from 'classes';
 import { TimeOnly } from 'classes';
 import { getDateResolverByName } from 'consts/date-resolvers';
 import { ClosurePreset } from 'interfaces/closure-preset';
-import Logger from 'js-logger';
+import { logger as baseLogger } from './logger';
 
-const logger = Logger.get('closure-presets');
+const logger = baseLogger.scope('closure-presets');
 
 function getStartDateForPreset(
   closureDetails: ClosurePreset['closureDetails'],
@@ -155,15 +155,15 @@ export function applyClosurePreset(
   const endDate = getEndDateForPreset(closureDetails, startDate);
 
   if (closureDetails.description) {
-    logger.log('Preset has a description. Applying..');
+    logger.debug('Preset has a description. Applying..');
     closureEditorForm.setDescription(closureDetails.description);
   }
 
-  logger.log('Applying resolved start timestamp', {
+  logger.debug('Applying resolved start timestamp', {
     value: startDate.toISOString(),
   });
   closureEditorForm.setStart(startDate);
-  logger.log('Applying resolved end timestamp', {
+  logger.debug('Applying resolved end timestamp', {
     value: endDate.toISOString(),
   });
   closureEditorForm.setEnd(endDate);

--- a/src/utils/logger.ts
+++ b/src/utils/logger.ts
@@ -1,0 +1,14 @@
+import { LogStream } from '@editor-x/wme-logstream';
+
+const scriptId = typeof __SCRIPT_ID__ !== 'undefined' ? __SCRIPT_ID__ : 'wme-closures-plus';
+const scriptVersion = typeof __SCRIPT_VERSION__ !== 'undefined' ? __SCRIPT_VERSION__ : '1.0.0';
+
+export const logger = LogStream.create({
+  minLogLevel: 'DEBUG',
+  persist: true,
+  dbPrefix: scriptId.replace('/', '-'),
+  scriptVersion: scriptVersion,
+  brand: {
+    scriptPrefix: 'editorx.dev/closures-plus',
+  },
+});


### PR DESCRIPTION
- Remove js-logger from dependencies and install @editor-x/wme-logstream.
- Create src/utils/logger.ts to instantiate the global LogStream logger.
- Replace manual log formatting and buffer logic in index.tsx with wme-logstream.
- Hook up 'Download Logs' option to download session logs as a compressed .xlog archive.
- Update all source files importing js-logger to utilize wme-logstream.
- Add Jest mock for wme-logstream to bypass ESM syntax errors.